### PR TITLE
fix(ConnectionListener): Fix board locked in fake mode

### DIFF
--- a/src/Connectivity/ConnectionListener.cpp
+++ b/src/Connectivity/ConnectionListener.cpp
@@ -116,7 +116,7 @@ bool ConnectionListener::Ping()
         }
         else
         {
-            LOG_INFO("Connection listener - failure pinging server.");
+            LOG_INFO("Connection listener - Failure pinging server.");
         }
     }
     return is_server_reachable;

--- a/src/Connectivity/ConnectionListener.cpp
+++ b/src/Connectivity/ConnectionListener.cpp
@@ -112,7 +112,7 @@ bool ConnectionListener::Ping()
         is_server_reachable = ping_result.value();
         if (is_server_reachable)
         {
-            LOG_INFO("Connection listener - success pinging server.");
+            LOG_INFO("Connection listener - Success pinging server.");
         }
         else
         {

--- a/src/Connectivity/ConnectionListener.cpp
+++ b/src/Connectivity/ConnectionListener.cpp
@@ -64,6 +64,10 @@ void ConnectionListener::ServerNokStateFunc()
                 state_ = State::kServerOk;
                 event_queue_.push(CONNECTED);
             }
+            else
+            {
+                LOG_INFO("Connection listener - Still disconnected, trying again in 30 seconds");
+            }
         }
     }
     else
@@ -85,6 +89,11 @@ void ConnectionListener::ServerOkStateFunc()
                 state_ = State::kServerNok;
                 event_queue_.push(DISCONNECTED);
             }
+            else
+            {
+                event_queue_.push(CONNECTED);
+                LOG_INFO("Connection listener - Still connected");
+            }
         }
     }
     else
@@ -95,11 +104,20 @@ void ConnectionListener::ServerOkStateFunc()
 
 bool ConnectionListener::Ping()
 {
+    LOG_INFO("Connection listener - Pinging server...");
     auto is_server_reachable = false;
     const auto ping_result = ServerCom_Ping();
     if (ping_result.has_value())
     {
         is_server_reachable = ping_result.value();
+        if (is_server_reachable)
+        {
+            LOG_INFO("Connection listener - success pinging server.");
+        }
+        else
+        {
+            LOG_INFO("Connection listener - failure pinging server.");
+        }
     }
     return is_server_reachable;
 }

--- a/src/Led/DataConverter.cpp
+++ b/src/Led/DataConverter.cpp
@@ -61,6 +61,7 @@ bool DataConv_IsHistoryDataValid(const uint8_t* const data, uint32_t data_length
 
     if (IsDataNullEmptyOrTooLong(data, data_length, kNumberOfHistoryFrames * kBufferSizeInBytes))
     {
+        LOG_DEBUG("DataConv - Data null, empty or too long");
         is_data_valid = false;
     }
     else
@@ -73,10 +74,28 @@ bool DataConv_IsHistoryDataValid(const uint8_t* const data, uint32_t data_length
             const auto n_leds_in_frame = (data[frame_start_index] << 8) + data[second_byte_in_frame];
             const auto frame_length = kBytesInHeader + n_leds_in_frame * kBytesPerLed;
             is_data_valid = DataConv_IsDataValid(&data[frame_start_index], frame_length);
+            if (!is_data_valid)
+            {
+                etl::string<64> msg("DataConv - Invalid frame at index: ");
+                etl::to_string(frame_start_index, msg, true);
+                LOG_ERROR(msg.c_str());
+            }
             frame_cnt++;
             frame_start_index += frame_length;
         }
 
+        if (kNumberOfHistoryFrames != frame_cnt)
+        {
+            etl::string<64> msg("DataConv - Wrong number of frames: ");
+            etl::to_string(frame_cnt, msg, true);
+            LOG_ERROR(msg.c_str());
+        }
+        if (frame_start_index != data_length)
+        {
+            etl::string<64> msg("DataConv - Frame start index does not match data length: ");
+            etl::to_string(frame_start_index, msg, true);
+            LOG_ERROR(msg.c_str());
+        }
         is_data_valid = is_data_valid && (kNumberOfHistoryFrames == frame_cnt);
         is_data_valid = is_data_valid && (frame_start_index == data_length);
     }


### PR DESCRIPTION
The connection listener now sends the `CONNECTED` signal each time it successfully polls the server. This way the state machine is not blocked in fake mode when it got there becaue of invalid data. 

Closes #6 